### PR TITLE
添加重邮仙桃校区的地址

### DIFF
--- a/cqupt_ics/location.py
+++ b/cqupt_ics/location.py
@@ -32,6 +32,14 @@ X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-TITLE=风雨操场(乒乓球馆)\\\\n\r
 		custom_geo = """LOCATION:重庆邮电学院篮球排球馆\\n崇文路2号重庆邮电大学内\r
 X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-TITLE=重庆邮电学院篮球排球馆\\\\n\r
  崇文路2号重庆邮电大学内:geo:29.534025,106.609148"""
+	elif "仙桃A08" in loc:
+		custom_geo = """LOCATION:重庆仙桃数据谷A08\\n中国重庆市渝北区金山大道仙桃国际大数据谷体验中心\r
+X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-TITLE=重庆仙桃数据谷A08\\\\n\r
+ 中国重庆市渝北区金山大道仙桃国际大数据谷体验中心:geo:29.739791,106.55661"""
+	elif "仙桃运动场" in loc:
+		custom_geo = """LOCATION:仙桃体育公园\\n中国重庆市渝北区金山大道仙桃国际大数据谷体验中心\r
+X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-TITLE=仙桃体育公园\\\\n\r
+ 中国重庆市渝北区仙桃街道数据谷东路仙桃国际数据谷内:geo:29.745789,106.55749""" 
 	elif room[0] == "1":
 		custom_geo = """LOCATION:重庆邮电大学-光电工程学院\\n崇文路2号重庆邮电大学内\r
 X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-TITLE=重庆邮电大学\r


### PR DESCRIPTION
重邮仙桃校区为 2022 年新开设的校区，校区内有本科生和研究生 400 余人。本 PR 在 `location.py` 文件中添加了重邮仙桃校区教学楼和运动场的地址，避免了 iOS 在设置提醒时间为需要离开时提醒时提前 1-2 小时发出提醒。经测试，生成的 `.ics` 文件在 iOS 15.7 上能够正常导入并显示地址。
![66BD0EBA25EBBE6EEB7DB2E9E3C21876](https://user-images.githubusercontent.com/60648876/218245889-c55a2e33-a586-45fe-b992-09a281214d27.png)
